### PR TITLE
Fix scrobbling playlist of episodes + movies

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,6 +137,10 @@
         }
         var self = this;
 
+        if (method.body && ((method.body.episode && params.movie) || (method.body.movie && params.episode))) {
+            method.body = params;
+        }
+
         var req = {
             method: method.method,
             url: this._parse(method, params),


### PR DESCRIPTION
There's probably a better way to do this, but this works for my specific use case.

The issue appears when scrobbling an episode, then stopping scrobbling and starting to scrobble a movie. (or vice versa)

Scrobbling just episodes or just movies works. This is because the query uses different params for movie/episode search and `method.body` (which seems to hold the previous query) is sent as the new query instead of `params`. (which seems to hold the current query)

This results in scrobbling the previous item instead of the new one.

The problematic line seems to be:
https://github.com/jaruba/trakt.tv/blob/master/index.js#L152
