### PR TITLE
Allow params with value 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@
             var queryParams = queryPart.split('&');
             for (var i in queryParams) {
                 var name = queryParams[i].split('=')[0];
-                if (params[name]) queryParts.push(name + '=' + params[name]);
+                if (params[name] || params[name] === 0) queryParts.push(name + '=' + params[name]);
             }
         }
 
@@ -176,7 +176,7 @@
                 pathParts.push(pathParams[k]);
             } else {
                 var param = params[pathParams[k].substr(1)];
-                if (param) pathParts.push(param);
+                if (param || param === 0) pathParts.push(param);
             }
         }
 


### PR DESCRIPTION
This change allows 0-value parameters to be accepted which previously were ignored, e.g. for the case of season 0 which is used for special episodes.

The code below should result in a call to the URL:
https://api-v2launch.trakt.tv/shows/41793/seasons/0

But it actually results in a call to the URL:
https://api-v2launch.trakt.tv/shows/41793/seasons

```
trakt.seasons.season({
  id : 41793,
  season : 0
})
```
