### PR TITLE
Allow authentication url to be used with the staging API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ const Trakt = require('trakt.tv');
 const trakt = new Trakt({
   client_id: <the_client_id>,
   client_secret: <the_client_secret>,
-  redirect_uri: null,   // fallbacks to 'urn:ietf:wg:oauth:2.0:oob'
-  api_url: null         // fallbacks to 'api-v2launch.trakt.tv'
+  redirect_uri: null,   // defaults to 'urn:ietf:wg:oauth:2.0:oob'
+  api_url: null         // defaults to 'https://api.trakt.tv'
 });
 ```
 

--- a/trakt.js
+++ b/trakt.js
@@ -280,10 +280,12 @@ module.exports = class Trakt {
     // Get authentication url for browsers
     get_url() {
         this._authentication.state = crypto.randomBytes(6).toString('hex');
-        return 'https://trakt.tv/oauth/authorize?response_type=code&client_id=' + this._settings.client_id + '&redirect_uri=' + this._settings.redirect_uri + '&state=' + this._authentication.state;
+        // Replace 'api' from the api_url to get the top level trakt domain
+        const base_url = this._settings.endpoint.replace('api.', '').replace('api-', '');
+        return base_url + '/oauth/authorize?response_type=code&client_id=' + this._settings.client_id + '&redirect_uri=' + this._settings.redirect_uri + '&state=' + this._authentication.state;
     }
 
-    // Verify code; optionnal state
+    // Verify code; optional state
     exchange_code(code, state) {
         if (state && state != this._authentication.state) throw Error('Invalid CSRF (State)');
 


### PR DESCRIPTION
Hey, I've found another thing that can be improved!

You can test against the [Trakt.tv API in a sandbox environment](http://docs.trakt.apiary.io/#introduction/api-url) without messing up your real account using `api-staging.trakt.tv`.

The authentication url you're building in `get_url` is hardcoded to `https://trakt.tv` so this change allows you to use the method, and start the OAuth process easily, with the staging API.

- It replaces `api.` from the api url in the settings, for the live api `api.trakt.tv` giving `trakt.tv/oauth/...`.
- It also replaces `api-` in case it's being used with `api-staging.trakt.tv` giving `staging.trakt.tv/oauth/...`.