### PR TITLE
Change how plugins are loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,19 @@ trakt.movies.popular({
 Note: _this will contain `data` and `pagination` for all calls, even if no pagination is available. it's typically for really advanced use only_
 
 #### Load plugins
-When calling `new Trakt()`, include desired plugins in an array (must be installed from npm):
+When calling `new Trakt()`, include desired plugins in an object (must be installed from npm):
 
 ```js
 const trakt = new Trakt({
     client_id: <the_client_id>,
     client_secret: <the_client_secret>,
-    plugins: ['ondeck'] // 'ondeck' refers to npm 'trakt.tv-ondeck' plugin
+    plugins: {
+        ondeck: require('trakt.tv-ondeck')
+    }
 });
 ```
+
+The plugin can be accessed with the key you specify. For example `trakt.ondeck...`.
 
 #### Write plugins
 See the [wiki page](https://github.com/vankasteelj/trakt.tv/wiki/Write-plugins-for-trakt.tv).

--- a/trakt.js
+++ b/trakt.js
@@ -54,8 +54,10 @@ module.exports = class Trakt {
         for (let name in plugins) {
             if (!plugins.hasOwnProperty(name)) continue;
 
+            const opts = options && options[name] ? options[name] : {};
+
             this[name] = plugins[name];
-            this[name].init(this);
+            this[name].init(this, opts);
             this._debug('Trakt.tv ' + name + ' plugin loaded');
         }
     }

--- a/trakt.js
+++ b/trakt.js
@@ -50,30 +50,13 @@ module.exports = class Trakt {
 
     // Initialize plugins
     _plugins(plugins, options) {
-        if (typeof plugins === 'string') plugins = [plugins];
-        if (typeof plugins !== 'object') return;
-
         const errors = [];
-        for (let i = 0; i < plugins.length; i++) {
-            const plugin = plugins[i].match('trakt.tv') !== null ? plugins[i] : 'trakt.tv-' + plugins[i];
-            const name = plugin.replace('trakt.tv-', '');
+        for (let name in plugins) {
+            if (!plugins.hasOwnProperty(name)) continue;
 
-            // init options
-            const opts = options && options[name] ? options[name] : {};
-
-            // init plugins
-            try {
-                this[name] = require(plugin);
-                this[name].init(this, opts);
-                this._debug('Trakt.tv ' + name + ' plugin loaded');
-            } catch (e) {
-                errors.push(name);
-                this._debug(e);
-            }
-        }
-
-        if (errors.length) {
-            throw Error(errors.join() + ': invalid plugin(s)');
+            this[name] = plugins[name];
+            this[name].init(this);
+            this._debug('Trakt.tv ' + name + ' plugin loaded');
         }
     }
 


### PR DESCRIPTION
Closes #20

Looks like the only thing I've missed is the `options` you can specify

```js
{
    ondeck: {} // options for the plugin
    plugins: ['ondeck']
}
```

Is this important or can you specify in the docs to pass options to the plugin when users require it?