### PR TITLE
Added an 'extended' optional query parameter to '/episodes/summary'

### DIFF
--- a/methods.json
+++ b/methods.json
@@ -786,8 +786,8 @@
             "pagination": false
         },
         "method": "GET",
-        "url": "/shows/:id/seasons/:season/episodes/:episode",
-        "optional": []
+        "url": "/shows/:id/seasons/:season/episodes/:episode?extended=",
+        "optional": ["extended"]
     },
     "/episodes/comments": {
         "opts": {


### PR DESCRIPTION
There is an optional 'extended' query URI parameter that is used to get more information about an episode.

Here is the official Trakt api doc:
http://docs.trakt.apiary.io/#reference/episodes/summary/get-a-single-episode-for-a-show

Setting 'extended' to 'full' returns many additional fields including the rating, votes, first_aired, updated_at, and an episode overview in addition to the basic episode summary which only includes the 'title' field and the 'ids' object.

For instance: 
`trakt.episodes.summary({
    id: 107460,
    season: 1,
    episode: 10,
    extended: 'full'
})`

Returns: 
`{ season: 1,
  number: 10,
  title: 'I Won\'t Be Defeated by Such a Tiny Setback',
  ids: 
   { trakt: 2323304,
     tvdb: 5727843,
     imdb: null,
     tmdb: 1221350,
     tvrage: 0 },
  number_abs: 10,
  overview: 'After Mizuki takes the lead for Seiseki, they put Kazama on Indou Kaoru. However, just five minutes later, Indou\'s shot lands in the net. Realizing that Indou is in a totally different league, for the first time, the bitter taste of defeat spreads in Kazama\'s mouth. That is when Kazama remembers how hard Tsukushi works and begins to engage Indou with an untypically inelegant play style.',
  rating: 7.57895,
  votes: 19,
  first_aired: '2016-09-03T17:58:00.000Z',
  updated_at: '2017-04-05T04:23:53.000Z',
  available_translations: [ 'el', 'en', 'es', 'fr' ],
  runtime: 24 }`