### PR TITLE
add `remove_token()` as counterpart of `import_token()`

### DIFF
--- a/trakt.js
+++ b/trakt.js
@@ -370,4 +370,11 @@ module.exports = class Trakt {
             this._authentication = {};
         }
     }
+    
+    // Remove token
+    remove_token() {
+      if (this._authentication.access_token) {
+            this._authentication = {};
+        }
+    }
 };


### PR DESCRIPTION
`revoke_token()` also tries to do stuff via request, so it can be a bad idea to call in some environments (browser, CORS issues). `remove_token()` only removed the tokens and is thus safe to use.