### PR TITLE
mark "type" parameter of "get watchlist" methods as optional

### DIFF
--- a/methods.json
+++ b/methods.json
@@ -987,11 +987,11 @@
     "/sync/watchlist/get": {
         "opts": {
             "auth": true,
-            "pagination": "optionnal"
+            "pagination": "optional"
         },
         "method": "GET",
         "url": "/sync/watchlist/:type",
-        "optional": []
+        "optional": ["type"]
     },
     "/sync/watchlist/add": {
         "opts": {
@@ -1305,7 +1305,7 @@
         },
         "method": "GET",
         "url": "/users/:username/watchlist/:type",
-        "optional": []
+        "optional": ["type"]
     },
     "/users/watching": {
         "opts": {

--- a/methods.json
+++ b/methods.json
@@ -987,7 +987,7 @@
     "/sync/watchlist/get": {
         "opts": {
             "auth": true,
-            "pagination": "optional"
+            "pagination": "optionnal"
         },
         "method": "GET",
         "url": "/sync/watchlist/:type",


### PR DESCRIPTION
You can also get a list of all watchlist items: 
http://docs.trakt.apiary.io/#reference/sync/get-watchlist/get-watchlist http://docs.trakt.apiary.io/#reference/users/watchlist/get-watchlist


