### PR TITLE
Fix revoke call

### DIFF
--- a/trakt.js
+++ b/trakt.js
@@ -103,12 +103,13 @@ module.exports = class Trakt {
             url: `${this._settings.endpoint}/oauth/revoke`,
             headers: {
                 'User-Agent': this._settings.useragent,
-                'Content-Type': 'application/x-www-form-urlencoded',
-                'Authorization' : `Bearer ${this._authentication.access_token}`,
-                'trakt-api-version': '2',
-                'trakt-api-key': this._settings.client_id
+                'Content-Type': 'application/json'
             },
-            body: `token=[${this._authentication.access_token}]`
+            body: JSON.stringify({
+                token: this._authentication.access_token,
+                client_id: this._settings.client_id,
+                client_secret: this._settings.client_secret
+            })
         };
         this._debug(req);
         got(req.url, req);


### PR DESCRIPTION
Token revocation was not working.
The request is sent and accepted by Trakt's API service, but the token is still usable.

Updated the call to fit the [description provided on the API docs](https://trakt.docs.apiary.io/#reference/authentication-oauth/revoke-token/revoke-an-access_token).
Confirmed that this fixes the issue.